### PR TITLE
Small bugfixes and refactoring (#53)

### DIFF
--- a/bit/base32.py
+++ b/bit/base32.py
@@ -18,12 +18,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-"""Reference implementation for Bech32 and segwit addresses."""
-
+from bit.constants import BECH32_VERSION_SET
 
 CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
 
-BECH32_VERSION_SET = ('bc', 'tb', 'bcrt')
 
 def bech32_polymod(values):
     """Internal function that computes the Bech32 checksum."""

--- a/bit/constants.py
+++ b/bit/constants.py
@@ -1,0 +1,43 @@
+
+# Transactions:
+VERSION_1 = 0x01.to_bytes(4, byteorder='little')
+MARKER = b'\x00'
+FLAG = b'\x01'
+SEQUENCE = 0xffffffff.to_bytes(4, byteorder='little')
+LOCK_TIME = 0x00.to_bytes(4, byteorder='little')
+HASH_TYPE = 0x01.to_bytes(4, byteorder='little')
+
+# Scripts:
+OP_0 = b'\x00'
+OP_CHECKLOCKTIMEVERIFY = b'\xb1'
+OP_CHECKSIG = b'\xac'
+OP_DUP = b'v'
+OP_EQUALVERIFY = b'\x88'
+OP_HASH160 = b'\xa9'
+OP_PUSH_20 = b'\x14'
+OP_PUSH_32 = b'\x20'
+OP_RETURN = b'\x6a'
+OP_EQUAL = b'\x87'
+
+MESSAGE_LIMIT = 40
+
+# Address formats:
+BECH32_VERSION_SET = ('bc', 'tb', 'bcrt')
+BECH32_MAIN_VERSION_SET = BECH32_VERSION_SET[:1]
+BECH32_TEST_VERSION_SET = BECH32_VERSION_SET[1:]
+MAIN_PUBKEY_HASH = b'\x00'
+MAIN_SCRIPT_HASH = b'\x05'
+TEST_PUBKEY_HASH = b'\x6f'
+TEST_SCRIPT_HASH = b'\xc4'
+
+# Keys:
+MAIN_PRIVATE_KEY = b'\x80'
+MAIN_BIP32_PUBKEY = b'\x04\x88\xb2\x1e'
+MAIN_BIP32_PRIVKEY = b'\x04\x88\xad\xe4'
+TEST_PRIVATE_KEY = b'\xef'
+TEST_BIP32_PUBKEY = b'\x045\x87\xcf'
+TEST_BIP32_PRIVKEY = b'\x045\x83\x94'
+PUBLIC_KEY_UNCOMPRESSED = b'\x04'
+PUBLIC_KEY_COMPRESSED_EVEN_Y = b'\x02'
+PUBLIC_KEY_COMPRESSED_ODD_Y = b'\x03'
+PRIVATE_KEY_COMPRESSED_PUBKEY = b'\x01'

--- a/bit/format.py
+++ b/bit/format.py
@@ -5,24 +5,13 @@ from bit.crypto import ripemd160_sha256, sha256
 from bit.curve import x_to_y
 
 from bit.utils import int_to_unknown_bytes, hex_to_bytes, script_push
-from bit.base32 import bech32_decode, BECH32_VERSION_SET
-
-BECH32_MAIN_VERSION_SET = BECH32_VERSION_SET[:1]
-BECH32_TEST_VERSION_SET = BECH32_VERSION_SET[1:]
-MAIN_PUBKEY_HASH = b'\x00'
-MAIN_SCRIPT_HASH = b'\x05'
-MAIN_PRIVATE_KEY = b'\x80'
-MAIN_BIP32_PUBKEY = b'\x04\x88\xb2\x1e'
-MAIN_BIP32_PRIVKEY = b'\x04\x88\xad\xe4'
-TEST_PUBKEY_HASH = b'\x6f'
-TEST_SCRIPT_HASH = b'\xc4'
-TEST_PRIVATE_KEY = b'\xef'
-TEST_BIP32_PUBKEY = b'\x045\x87\xcf'
-TEST_BIP32_PRIVKEY = b'\x045\x83\x94'
-PUBLIC_KEY_UNCOMPRESSED = b'\x04'
-PUBLIC_KEY_COMPRESSED_EVEN_Y = b'\x02'
-PUBLIC_KEY_COMPRESSED_ODD_Y = b'\x03'
-PRIVATE_KEY_COMPRESSED_PUBKEY = b'\x01'
+from bit.base32 import bech32_decode
+from bit.constants import (
+    BECH32_MAIN_VERSION_SET, BECH32_TEST_VERSION_SET, MAIN_PUBKEY_HASH,
+    MAIN_SCRIPT_HASH, MAIN_PRIVATE_KEY, TEST_PUBKEY_HASH, TEST_SCRIPT_HASH,
+    TEST_PRIVATE_KEY, PUBLIC_KEY_UNCOMPRESSED, PUBLIC_KEY_COMPRESSED_EVEN_Y,
+    PUBLIC_KEY_COMPRESSED_ODD_Y, PRIVATE_KEY_COMPRESSED_PUBKEY
+)
 
 
 def verify_sig(signature, data, public_key):

--- a/bit/wallet.py
+++ b/bit/wallet.py
@@ -11,9 +11,9 @@ from bit.network import NetworkAPI, get_fee_cached, satoshi_to_currency_cached
 from bit.network.meta import Unspent
 from bit.transaction import (
     calc_txid, create_new_transaction, sanitize_tx_data, sign_tx,
-    OP_CHECKSIG, OP_DUP, OP_EQUALVERIFY, OP_HASH160, OP_PUSH_20,
     deserialize, address_to_scriptpubkey
-    )
+)
+from bit.constants import OP_0, OP_PUSH_20, OP_PUSH_32
 
 from bit.utils import bytes_to_hex, int_to_varint
 
@@ -179,14 +179,12 @@ class PrivateKey(BaseKey):
 
     @property
     def scriptcode(self):
-        self._scriptcode = (OP_DUP + OP_HASH160 + OP_PUSH_20 +
-                            address_to_public_key_hash(self.address) +
-                            OP_EQUALVERIFY + OP_CHECKSIG)
+        self._scriptcode = address_to_scriptpubkey(self.address)
         return self._scriptcode
 
     @property
     def segwit_scriptcode(self):
-        self._segwit_scriptcode = (b'\x00' + b'\x14'
+        self._segwit_scriptcode = (OP_0 + OP_PUSH_20
                                    + ripemd160_sha256(self.public_key))
         return self._segwit_scriptcode
 
@@ -238,7 +236,7 @@ class PrivateKey(BaseKey):
             NetworkAPI.get_unspent(self.address)
         ))
         self.unspents += list(map(
-            lambda u: u.set_type('np2wpkh'),
+            lambda u: u.set_type('np2wkh'),
             NetworkAPI.get_unspent(self.segwit_address)
         ))
         self.balance = sum(unspent.amount for unspent in self.unspents)
@@ -546,14 +544,12 @@ class PrivateKeyTestnet(BaseKey):
 
     @property
     def scriptcode(self):
-        self._scriptcode = (OP_DUP + OP_HASH160 + OP_PUSH_20 +
-                            address_to_public_key_hash(self.address) +
-                            OP_EQUALVERIFY + OP_CHECKSIG)
+        self._scriptcode = address_to_scriptpubkey(self.address)
         return self._scriptcode
 
     @property
     def segwit_scriptcode(self):
-        self._segwit_scriptcode = (b'\x00' + b'\x14'
+        self._segwit_scriptcode = (OP_0 + OP_PUSH_20
                                    + ripemd160_sha256(self.public_key))
         return self._segwit_scriptcode
 
@@ -605,7 +601,7 @@ class PrivateKeyTestnet(BaseKey):
             NetworkAPI.get_unspent_testnet(self.address)
         ))
         self.unspents += list(map(
-            lambda u: u.set_type('np2wpkh'),
+            lambda u: u.set_type('np2wkh'),
             NetworkAPI.get_unspent_testnet(self.segwit_address)
         ))
         self.balance = sum(unspent.amount for unspent in self.unspents)
@@ -938,7 +934,7 @@ class MultiSig:
         return self._scriptcode
 
     def segwit_scriptcode(self):
-        self._segwit_scriptcode = (b'\x00' + b'\x20'
+        self._segwit_scriptcode = (OP_0 + OP_PUSH_32
                                    + sha256(self.redeemscript))
         return self._segwit_scriptcode
 
@@ -1277,8 +1273,8 @@ class MultiSigTestnet:
 
     @property
     def segwit_scriptcode(self):
-        self._segwit_scriptcode = (b'\x00' + b'\x20' +
-                               sha256(self.redeemscript))
+        self._segwit_scriptcode = (OP_0 + OP_PUSH_32
+                                   + sha256(self.redeemscript))
         return self._segwit_scriptcode
 
     def can_sign_unspent(self, unspent):

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -240,7 +240,6 @@ class TestTxObj:
         txout = [TxOut(b'\x88\x13\x00\x00\x00\x00\x00\x00', b'script_pubkey')]
         txobj = TxObj(b'\x01\x00\x00\x00', txin, txout, b'\x00\x00\x00\x00')
         assert txobj.version == b'\x01\x00\x00\x00'
-        assert txobj.marker+txobj.flag == b'\x00\x01'
         assert txobj.TxIn == txin
         assert txobj.TxOut == txout
         assert txobj.locktime == b'\x00\x00\x00\x00'
@@ -471,7 +470,6 @@ class TestDeserializeTransaction:
     def test_legacy_deserialize(self):
         txobj = deserialize(FINAL_TX_1)
         assert txobj.version == hex_to_bytes(FINAL_TX_1[:8])
-        assert txobj.marker+txobj.flag == b''
         assert len(txobj.TxIn) == 1
         assert txobj.TxIn[0].txid == hex_to_bytes(FINAL_TX_1[10:74])
         assert txobj.TxIn[0].txindex == hex_to_bytes(FINAL_TX_1[74:82])
@@ -491,7 +489,6 @@ class TestDeserializeTransaction:
     def test_segwit_deserialize(self):
         txobj = deserialize(SEGWIT_TX_1)
         assert txobj.version == hex_to_bytes(SEGWIT_TX_1[:8])
-        assert txobj.marker+txobj.flag == hex_to_bytes(SEGWIT_TX_1[8:12])
         assert len(txobj.TxIn) == 2
         assert txobj.TxIn[0].txid == hex_to_bytes(SEGWIT_TX_1[14:78])
         assert txobj.TxIn[0].txindex == hex_to_bytes(SEGWIT_TX_1[78:86])
@@ -648,5 +645,9 @@ class TestConstructOutputBlock:
         assert outs[1].amount == amount and outs[1].script_pubkey.hex() == '0020' + BITCOIN_SEGWIT_HASH_TEST_PAY2SH
 
 
-def test_calc_txid():
-    assert calc_txid(FINAL_TX_1) == 'e6922a6e3f1ff422113f15543fbe1340a727441202f55519640a70ac4636c16f'
+class TestCalcTxId:
+    def test_calc_txid_legacy(self):
+        assert calc_txid(FINAL_TX_1) == 'e6922a6e3f1ff422113f15543fbe1340a727441202f55519640a70ac4636c16f'
+
+    def test_calc_txid_segwit(self):
+        assert calc_txid(SEGWIT_TX_1) == 'a103ed36e9afee8b4001b1c3970ba8cd9839ff95e8b8af3fbe6016f6287bf9c6'


### PR DESCRIPTION
* Fixes calculating transaction id for Segwit transactions

* Simplifies bytes representation of segwit TxObj

* Improves validating signatures when extracting from a multisig scriptSig

* Fixes mistake in unspent type when calling get_unspents()

* Moves all constants used by different modules into one file

* Fixes DRYs in wallet.py

* Refactors the code for calculating the transaction preimage to sign

* Uses coincurve to verify signatures in get_signatures_from_script()

Uses coincurve to extract only DER-encoded signatures with get_signatures_from_script()

* Adds docstring to calculate_preimages()

* Improves loop in get_signatures_from_script()